### PR TITLE
Add flashcards data and route

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,18 @@
 # French Learning App
 
-This repository contains a very small Flask application. It simply returns "Hello, world!" when accessed and can be deployed to [Render](https://render.com/).
+This repository contains a small Flask application. It exposes a single route returning "Hello, world!" and includes starter data for French flashcards.
+
+## Flashcard Data
+
+The `flashcards.py` module defines a simple `Flashcard` dataclass and an initial set of cards:
+
+- Le Chat → Cat
+- Le Chien → Dog
+- La Maison → House
+- Le Homme → Man
+- L'Amour → Love
+
+These cards can be imported by future parts of the application to present them to users.
 
 ## Local Development
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,6 @@
-from flask import Flask
+from flask import Flask, jsonify
+from dataclasses import asdict
+from flashcards import flashcards
 import os
 
 app = Flask(__name__)
@@ -6,6 +8,11 @@ app = Flask(__name__)
 @app.route("/")
 def hello():
     return "Hello, world!"
+
+@app.route("/flashcards")
+def list_flashcards():
+    """Return all flashcards as JSON."""
+    return jsonify([asdict(card) for card in flashcards])
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))

--- a/flashcards.py
+++ b/flashcards.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+@dataclass
+class Flashcard:
+    front: str  # French word
+    back: str   # English translation
+
+# Initial set of flashcards
+flashcards = [
+    Flashcard(front="Le Chat", back="Cat"),
+    Flashcard(front="Le Chien", back="Dog"),
+    Flashcard(front="La Maison", back="House"),
+    Flashcard(front="Le Homme", back="Man"),
+    Flashcard(front="L'Amour", back="Love"),
+]


### PR DESCRIPTION
## Summary
- add dataclass `Flashcard` with five starter cards
- document the card data in README
- expose `/flashcards` endpoint returning the cards as JSON

## Testing
- `python -m py_compile flashcards.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848dd496154832599aabb5932f379b3