### PR TITLE
Add HTML flashcards page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 from dataclasses import asdict
 from flashcards import flashcards
 import os
@@ -10,6 +10,11 @@ def hello():
     return "Hello, world!"
 
 @app.route("/flashcards")
+def flashcards_page():
+    """Render a page with visual flashcards."""
+    return render_template("flashcards.html", flashcards=flashcards)
+
+@app.route("/api/flashcards")
 def list_flashcards():
     """Return all flashcards as JSON."""
     return jsonify([asdict(card) for card in flashcards])

--- a/templates/flashcards.html
+++ b/templates/flashcards.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Flashcards</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            margin-top: 40px;
+        }
+        #cards {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .flashcard {
+            position: relative;
+            width: 2in;
+            height: 2in;
+            margin-bottom: 20px;
+            transform-style: preserve-3d;
+            transition: transform 0.6s;
+            cursor: pointer;
+        }
+        .flashcard.flipped {
+            transform: rotateY(180deg);
+        }
+        .side {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border: 1px solid #000;
+            border-radius: 8px;
+            backface-visibility: hidden;
+            background: #fff;
+        }
+        .back {
+            transform: rotateY(180deg);
+        }
+    </style>
+</head>
+<body>
+    <div id="cards">
+        {% for card in flashcards %}
+        <div class="flashcard" style="z-index: {{ loop.revindex }};">
+            <div class="side front">{{ card.front }}</div>
+            <div class="side back">{{ card.back }}</div>
+        </div>
+        {% endfor %}
+    </div>
+
+<script>
+    document.querySelectorAll('.flashcard').forEach(function(card){
+        card.addEventListener('click', function(){
+            card.classList.toggle('flipped');
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- render a deck of flashcards on `/flashcards`
- keep JSON list under `/api/flashcards`
- add template for interactive cards

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848dee5ced883258e4c3b37d76077fc