### PR TITLE
Single card view for /flashcards

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 # French Learning App
 
-This repository contains a small Flask application. It exposes a single route returning "Hello, world!" and includes starter data for French flashcards.
+This repository contains a small Flask application. It exposes a single route returning "Hello, world!" and includes starter data for French flashcards. The `/flashcards` page presents these cards in an interactive layout where you can flip each card and move back and forth through the deck.
 
 ## Flashcard Data
 

--- a/templates/flashcards.html
+++ b/templates/flashcards.html
@@ -2,28 +2,33 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Flashcards</title>
     <style>
         body {
             font-family: Arial, sans-serif;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
+            align-items: center;
             margin-top: 40px;
         }
-        #cards {
-            display: grid;
-            grid-template-columns: repeat(5, 1fr);
-            gap: 20px;
-            justify-items: center;
+        #card-container {
+            position: relative;
+            width: 80vw;
+            height: 80vw;
+            max-width: 300px;
+            max-height: 300px;
         }
         .flashcard {
-            position: relative;
-            width: 2in;
-            height: 2in;
-            margin: 0;
+            position: absolute;
+            width: 100%;
+            height: 100%;
             transform-style: preserve-3d;
             transition: transform 0.6s;
             cursor: pointer;
+        }
+        .flashcard:not(.active) {
+            display: none;
         }
         .flashcard.flipped {
             transform: rotateY(180deg);
@@ -45,24 +50,80 @@
             transform: rotateY(180deg);
             color: blue;
         }
+        nav {
+            margin-top: 20px;
+        }
+        button {
+            padding: 10px 20px;
+        }
+        @media (max-width: 500px) {
+            #card-container {
+                width: 90vw;
+                height: 90vw;
+                max-width: 250px;
+                max-height: 250px;
+            }
+            button {
+                padding: 8px 12px;
+            }
+        }
     </style>
 </head>
 <body>
-    <div id="cards">
+    <div id="card-container">
         {% for card in flashcards %}
-        <div class="flashcard" style="z-index: {{ loop.revindex }};">
+        <div class="flashcard{% if loop.index0 == 0 %} active{% endif %}">
             <div class="side front">{{ card.front }}</div>
             <div class="side back">{{ card.back }}</div>
         </div>
         {% endfor %}
     </div>
-
+    <nav>
+        <button id="prev">Previous</button>
+        <button id="next">Next</button>
+    </nav>
 <script>
-    document.querySelectorAll('.flashcard').forEach(function(card){
-        card.addEventListener('click', function(){
+    const cards = document.querySelectorAll('.flashcard');
+    let current = 0;
+    const prev = document.getElementById('prev');
+    const next = document.getElementById('next');
+
+    function updateNav() {
+        prev.disabled = current === 0;
+        next.disabled = current === cards.length - 1;
+    }
+
+    function showCard(index) {
+        cards[current].classList.remove('active', 'flipped');
+        cards[current].style.display = 'none';
+        current = index;
+        cards[current].classList.add('active');
+        cards[current].style.display = 'block';
+        updateNav();
+    }
+
+    cards.forEach((card, i) => {
+        card.addEventListener('click', () => {
             card.classList.toggle('flipped');
         });
+        if (i !== 0) {
+            card.style.display = 'none';
+        }
     });
+
+    prev.addEventListener('click', () => {
+        if (current > 0) {
+            showCard(current - 1);
+        }
+    });
+
+    next.addEventListener('click', () => {
+        if (current < cards.length - 1) {
+            showCard(current + 1);
+        }
+    });
+
+    updateNav();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show one flashcard at a time with previous/next buttons
- responsive layout for small screens
- document interactive flashcard page

## Testing
- `python -m py_compile app.py flashcards.py`


------
https://chatgpt.com/codex/tasks/task_e_6848ea2a84c88325bb5d5944f3d68826