### PR TITLE
Add SQLAlchemy model and initial migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,18 @@
 from flask import Flask, jsonify, render_template
+from flask_migrate import Migrate
 from dataclasses import asdict
 from flashcards import flashcards
+from models import db
 import os
 
 app = Flask(__name__)
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
+    "DATABASE_URL", "sqlite:///app.db"
+)
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+db.init_app(app)
+migrate = Migrate(app, db)
 
 @app.route("/")
 def hello():

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,7 @@
+This directory contains the database migration files managed by Flask-Migrate
+(Alembic). To create or apply migrations, use the Flask CLI:
+
+```
+flask db migrate -m "<message>"
+flask db upgrade
+```

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,55 @@
+from __future__ import with_statement
+
+from logging.config import fileConfig
+
+from flask import current_app
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# provide the target metadata for 'autogenerate' support
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode."""
+
+    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode."""
+
+    connectable = current_app.extensions['migrate'].db.engine
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = '${up_revision}'
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+${upgrades if upgrades else "    pass"}
+
+
+def downgrade():
+${downgrades if downgrades else "    pass"}

--- a/migrations/versions/0001_initial_words_table.py
+++ b/migrations/versions/0001_initial_words_table.py
@@ -1,0 +1,49 @@
+"""initial words table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'words',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('french', sa.Text(), nullable=False),
+        sa.Column('english', sa.Text(), nullable=False),
+        sa.Column(
+            'part_of_speech',
+            sa.Text(),
+            sa.CheckConstraint(
+                "part_of_speech IN ('noun', 'verb', 'adjective', 'adverb', 'pronoun', 'preposition', 'conjunction', 'interjection', 'phrase', 'other')"
+            ),
+        ),
+        sa.Column(
+            'gender',
+            sa.Text(),
+            sa.CheckConstraint("gender IN ('m', 'f', 'n/a')"),
+        ),
+        sa.Column('is_plural', sa.Boolean(), server_default=sa.text('false')),
+        sa.Column('is_reflexive', sa.Boolean(), server_default=sa.text('false')),
+        sa.Column(
+            'preposition',
+            sa.Text(),
+            sa.CheckConstraint(
+                "preposition IN ('à', 'de', 'à + inf', 'de + inf', 'none', 'other')"
+            ),
+            server_default='none',
+        ),
+        sa.Column('example_sentence_fr', sa.Text()),
+        sa.Column('example_sentence_en', sa.Text()),
+        sa.Column('notes', sa.Text()),
+        sa.Column('frequency_rank', sa.Integer(), sa.CheckConstraint('frequency_rank > 0')),
+    )
+
+
+def downgrade():
+    op.drop_table('words')

--- a/models.py
+++ b/models.py
@@ -1,0 +1,41 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Initialize SQLAlchemy without an app for application factory compatibility
+# The app will call `db.init_app(app)`
+db = SQLAlchemy()
+
+class Word(db.Model):
+    __tablename__ = 'words'
+
+    id = db.Column(db.Integer, primary_key=True)
+    french = db.Column(db.Text, nullable=False)
+    english = db.Column(db.Text, nullable=False)
+    part_of_speech = db.Column(
+        db.Text,
+        db.CheckConstraint(
+            "part_of_speech IN ('noun', 'verb', 'adjective', 'adverb', 'pronoun', 'preposition', 'conjunction', 'interjection', 'phrase', 'other')"
+        ),
+    )
+    gender = db.Column(
+        db.Text,
+        db.CheckConstraint("gender IN ('m', 'f', 'n/a')"),
+    )
+    is_plural = db.Column(db.Boolean, server_default=db.text('false'))
+    is_reflexive = db.Column(db.Boolean, server_default=db.text('false'))
+    preposition = db.Column(
+        db.Text,
+        db.CheckConstraint(
+            "preposition IN ('à', 'de', 'à + inf', 'de + inf', 'none', 'other')"
+        ),
+        server_default='none'
+    )
+    example_sentence_fr = db.Column(db.Text)
+    example_sentence_en = db.Column(db.Text)
+    notes = db.Column(db.Text)
+    frequency_rank = db.Column(
+        db.Integer,
+        db.CheckConstraint('frequency_rank > 0')
+    )
+
+    def __repr__(self) -> str:
+        return f"<Word {self.french} - {self.english}>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 Flask
+Flask-SQLAlchemy
+Flask-Migrate
+psycopg2-binary


### PR DESCRIPTION
## Summary
- set up Flask-SQLAlchemy and Flask-Migrate in the app
- define `Word` model for words table
- add migration scripts for the initial schema
- update requirements with database packages

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684c80baf00483259f99a2f3f7d6ca91