### PR TITLE
[french_learning_app] Refactor Airtable logic

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -1,0 +1,37 @@
+import requests
+import sys
+import traceback
+from typing import List
+
+from flashcards import Flashcard
+
+
+AIRTABLE_URL = "https://api.airtable.com/v0/applW7zbiH23gDDCK/french_words"
+
+
+def fetch_flashcards(api_key: str) -> List[Flashcard]:
+    """Fetch flashcards from Airtable given an API key."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in range(1, 21)]) + ")"
+    params = {
+        "maxRecords": 20,
+        "filterByFormula": formula,
+        "sort[0][field]": "Frequency",
+        "sort[0][direction]": "asc",
+    }
+    try:
+        resp = requests.get(AIRTABLE_URL, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        flashcards: List[Flashcard] = []
+        for rec in data.get("records", []):
+            fields = rec.get("fields", {})
+            front = fields.get("french_word", "")
+            back = fields.get("english_word", "")
+            if front or back:
+                flashcards.append(Flashcard(front=front, back=back))
+        return flashcards
+    except Exception:
+        print("Error fetching flashcards from Airtable", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+    return []

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from airtable_data_access import fetch_flashcards, AIRTABLE_URL
+from flashcards import Flashcard
+
+
+class FetchFlashcardsTests(unittest.TestCase):
+    @patch('airtable_data_access.requests.get')
+    def test_query_parameters(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"records": []}
+        mock_get.return_value = mock_resp
+
+        fetch_flashcards('TOKEN')
+
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], AIRTABLE_URL)
+        self.assertEqual(kwargs['headers'], {'Authorization': 'Bearer TOKEN'})
+        formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in range(1, 21)]) + ")"
+        expected_params = {
+            'maxRecords': 20,
+            'filterByFormula': formula,
+            'sort[0][field]': 'Frequency',
+            'sort[0][direction]': 'asc',
+        }
+        self.assertEqual(kwargs['params'], expected_params)
+
+    @patch('airtable_data_access.requests.get')
+    def test_parses_flashcards(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "records": [
+                {"fields": {"french_word": "Bonjour", "english_word": "Hello"}},
+                {"fields": {"french_word": "", "english_word": "Empty"}},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        cards = fetch_flashcards('TOKEN')
+
+        self.assertEqual(cards, [Flashcard(front="Bonjour", back="Hello"), Flashcard(front="", back="Empty")])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- move Airtable fetch logic into `airtable_data_access.py`
- import and use `fetch_flashcards` in `app.py`
- add unit tests for query formation and parsing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603f27a578832586e4169651f62e73