### PR TITLE
[french_learning_app] Randomize Airtable flashcard selection

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -1,6 +1,7 @@
 import requests
 import sys
 import traceback
+import random
 from typing import List
 
 from flashcards import Flashcard
@@ -10,10 +11,17 @@ AIRTABLE_URL = "https://api.airtable.com/v0/applW7zbiH23gDDCK/french_words"
 SPACED_REP_URL = "https://api.airtable.com/v0/applW7zbiH23gDDCK/spaced_rep"
 
 
+def get_random_frequencies(count: int = 20, max_frequency: int = 200) -> List[int]:
+    """Return ``count`` unique random frequency values between 1 and ``max_frequency``."""
+    population = list(range(1, max_frequency + 1))
+    return random.sample(population, count)
+
+
 def fetch_flashcards(api_key: str) -> List[Flashcard]:
     """Fetch flashcards from Airtable given an API key."""
     headers = {"Authorization": f"Bearer {api_key}"}
-    formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in range(1, 21)]) + ")"
+    selected = get_random_frequencies()
+    formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in selected]) + ")"
     params = {
         "maxRecords": 20,
         "filterByFormula": formula,
@@ -28,7 +36,7 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
         for rec in data.get("records", []):
             fields = rec.get("fields", {})
             front = fields.get("french_word", "")
-            back = fields.get("english_word", "")
+            back = fields.get("english_translation", "")
             freq = str(fields.get("Frequency", ""))
             if front or back:
                 flashcards.append(


### PR DESCRIPTION
## Summary
- support randomly selecting frequencies when querying Airtable
- fetch translations from the `english_translation` field
- unit test `get_random_frequencies` usage and parsing logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686052fa0d748325acc7fdc8ecf9aadd