### PR TITLE
[french_learning_app] Handle AI translation field

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -36,7 +36,7 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
         for rec in data.get("records", []):
             fields = rec.get("fields", {})
             front = fields.get("french_word", "")
-            back = fields.get("english_translation", "")
+            back = fields.get("english_translation", {}).get("value", "")
             freq = str(fields.get("Frequency", ""))
             if front or back:
                 flashcards.append(

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -47,8 +47,20 @@ class FetchFlashcardsTests(unittest.TestCase):
         mock_resp.raise_for_status.return_value = None
         mock_resp.json.return_value = {
             "records": [
-                {"fields": {"french_word": "Bonjour", "english_translation": "Hello", "Frequency": "2"}},
-                {"fields": {"french_word": "", "english_translation": "Empty", "Frequency": "5"}},
+                {
+                    "fields": {
+                        "french_word": "Bonjour",
+                        "english_translation": {"value": "Hello"},
+                        "Frequency": "2",
+                    }
+                },
+                {
+                    "fields": {
+                        "french_word": "",
+                        "english_translation": {"value": "Empty"},
+                        "Frequency": "5",
+                    }
+                },
             ]
         }
         mock_get.return_value = mock_resp
@@ -62,6 +74,28 @@ class FetchFlashcardsTests(unittest.TestCase):
                 Flashcard(front="", back="Empty", frequency="5"),
             ],
         )
+
+    @patch('airtable_data_access.get_random_frequencies', return_value=list(range(1, 21)))
+    @patch('airtable_data_access.requests.get')
+    def test_handles_translation_dict(self, mock_get, mock_rand):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "records": [
+                {
+                    "fields": {
+                        "french_word": "Savoir",
+                        "english_translation": {"state": "generated", "value": "to know", "isStale": False},
+                        "Frequency": "7",
+                    }
+                },
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        cards = fetch_flashcards('TOKEN')
+
+        self.assertEqual(cards, [Flashcard(front="Savoir", back="to know", frequency="7")])
 
     @patch('airtable_data_access.requests.post')
     def test_log_practice(self, mock_post):


### PR DESCRIPTION
## Summary
- fix `fetch_flashcards` to assume Airtable returns dicts for `english_translation`
- update parsing tests to use dict formatted translations

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686055a11b30832598b6405a5a83d6de