### PR TITLE
[french_learning_app] Add level tracking for spaced repetition

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -2,7 +2,7 @@ import requests
 import sys
 import traceback
 import random
-from typing import List
+from typing import List, Dict, Sequence
 
 from flashcards import Flashcard
 
@@ -42,6 +42,14 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
                 flashcards.append(
                     Flashcard(front=front, back=back, frequency=freq)
                 )
+
+        # Fetch existing levels for the selected frequencies
+        frequencies = [c.frequency for c in flashcards if c.frequency]
+        level_map = fetch_levels(api_key, frequencies)
+        for card in flashcards:
+            if card.frequency:
+                card.level = level_map.get(card.frequency, 1)
+
         return flashcards
     except Exception:
         print("Error fetching flashcards from Airtable", file=sys.stderr)
@@ -64,3 +72,69 @@ def log_practice(api_key: str, frequency: str, date_str: str) -> bool:
         print("Error recording practice in Airtable", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         return False
+
+
+def fetch_levels(api_key: str, frequencies: Sequence[str]) -> Dict[str, int]:
+    """Return a mapping of frequency to level from Airtable."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if not frequencies:
+        return {}
+    formula = "OR(" + ",".join([f"{{Frequency}} = '{f}'" for f in frequencies]) + ")"
+    params = {"filterByFormula": formula}
+    try:
+        resp = requests.get(SPACED_REP_URL, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        levels = {}
+        for rec in data.get("records", []):
+            fields = rec.get("fields", {})
+            freq = str(fields.get("Frequency", ""))
+            level = int(fields.get("level", 1))
+            if freq:
+                levels[freq] = level
+        return levels
+    except Exception:
+        print("Error fetching levels from Airtable", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return {}
+
+
+def update_level(api_key: str, frequency: str, delta: int) -> int | None:
+    """Update the level for ``frequency`` by ``delta`` and return the new level."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    formula = f"{{Frequency}} = '{frequency}'"
+    try:
+        resp = requests.get(
+            SPACED_REP_URL, headers=headers, params={"filterByFormula": formula}
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("records"):
+            rec = data["records"][0]
+            record_id = rec["id"]
+            current = int(rec.get("fields", {}).get("level", 1))
+        else:
+            record_id = None
+            current = 1
+
+        new_level = max(1, min(5, current + delta))
+
+        if record_id is None:
+            payload = {"fields": {"Frequency": frequency, "level": new_level}}
+            resp = requests.post(SPACED_REP_URL, headers=headers, json=payload)
+        elif new_level != current:
+            url = f"{SPACED_REP_URL}/{record_id}"
+            payload = {"fields": {"level": new_level}}
+            resp = requests.patch(url, headers=headers, json=payload)
+        else:
+            return new_level
+
+        resp.raise_for_status()
+        return new_level
+    except Exception:
+        print("Error updating level in Airtable", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return None

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flashcards import flashcards, Flashcard
 import os
 import sys
 from datetime import datetime
-from airtable_data_access import fetch_flashcards, log_practice
+from airtable_data_access import fetch_flashcards, log_practice, update_level
 
 app = Flask(__name__)
 
@@ -44,8 +44,9 @@ def record_practice():
     """Record practice of a flashcard."""
     data = request.get_json(force=True)
     freq = data.get("frequency")
-    if not freq:
-        return jsonify({"error": "frequency required"}), 400
+    action = data.get("action")
+    if not freq or action not in {"got_it", "forgot_it"}:
+        return jsonify({"error": "frequency and action required"}), 400
     api_key = os.environ.get("AIRTABLE_API_KEY")
     if not api_key:
         print("AIRTABLE_API_KEY environment variable not set", file=sys.stderr)
@@ -54,7 +55,12 @@ def record_practice():
     success = log_practice(api_key, freq, date_str)
     if not success:
         return jsonify({"error": "logging failed"}), 500
-    return jsonify({"status": "ok"})
+
+    delta = 1 if action == "got_it" else -1
+    level = update_level(api_key, freq, delta)
+    if level is None:
+        return jsonify({"error": "level update failed"}), 500
+    return jsonify({"status": "ok", "level": level})
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))

--- a/flashcards.py
+++ b/flashcards.py
@@ -6,6 +6,7 @@ class Flashcard:
     front: str  # French word
     back: str   # English translation
     frequency: str | None = None
+    level: int | None = None
 
 
 # Initial set of flashcards

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -97,7 +97,7 @@
 <body>
     <div id="card-container">
         {% for card in flashcards %}
-        <div class="flashcard{% if loop.index0 == 0 %} active{% endif %}" data-frequency="{{ card.frequency }}">
+        <div class="flashcard{% if loop.index0 == 0 %} active{% endif %}" data-frequency="{{ card.frequency }}" data-level="{{ card.level }}">
             <div class="side front">{{ card.front }}</div>
             <div class="side back">
                 <div class="back-text">{{ card.back }}</div>
@@ -147,15 +147,18 @@
     document.querySelectorAll('.back-action').forEach(btn => {
         btn.addEventListener('click', (e) => {
             e.stopPropagation();
-            if (btn.textContent.includes('I Got It')) {
-                const card = btn.closest('.flashcard');
-                const freq = card.dataset.frequency;
-                fetch('/api/practice', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ frequency: freq })
-                });
-            }
+            const card = btn.closest('.flashcard');
+            const freq = card.dataset.frequency;
+            const action = btn.textContent.includes('I Got It') ? 'got_it' : 'forgot_it';
+            fetch('/api/practice', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ frequency: freq, action: action })
+            }).then(r => r.json()).then(data => {
+                if (data.level !== undefined) {
+                    card.dataset.level = data.level;
+                }
+            });
         });
     });
 

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -8,6 +8,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from airtable_data_access import (
     fetch_flashcards,
     log_practice,
+    fetch_levels,
+    update_level,
     AIRTABLE_URL,
     SPACED_REP_URL,
 )
@@ -15,9 +17,10 @@ from flashcards import Flashcard
 
 
 class FetchFlashcardsTests(unittest.TestCase):
+    @patch('airtable_data_access.fetch_levels', return_value={})
     @patch('airtable_data_access.get_random_frequencies')
     @patch('airtable_data_access.requests.get')
-    def test_query_parameters(self, mock_get, mock_rand):
+    def test_query_parameters(self, mock_get, mock_rand, mock_levels):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.json.return_value = {"records": []}
@@ -40,9 +43,10 @@ class FetchFlashcardsTests(unittest.TestCase):
         }
         self.assertEqual(kwargs['params'], expected_params)
 
+    @patch('airtable_data_access.fetch_levels', return_value={'2': 1, '5': 1})
     @patch('airtable_data_access.get_random_frequencies', return_value=list(range(1, 21)))
     @patch('airtable_data_access.requests.get')
-    def test_parses_flashcards(self, mock_get, mock_rand):
+    def test_parses_flashcards(self, mock_get, mock_rand, mock_levels):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.json.return_value = {
@@ -70,14 +74,15 @@ class FetchFlashcardsTests(unittest.TestCase):
         self.assertEqual(
             cards,
             [
-                Flashcard(front="Bonjour", back="Hello", frequency="2"),
-                Flashcard(front="", back="Empty", frequency="5"),
+                Flashcard(front="Bonjour", back="Hello", frequency="2", level=1),
+                Flashcard(front="", back="Empty", frequency="5", level=1),
             ],
         )
 
+    @patch('airtable_data_access.fetch_levels', return_value={'7': 1})
     @patch('airtable_data_access.get_random_frequencies', return_value=list(range(1, 21)))
     @patch('airtable_data_access.requests.get')
-    def test_handles_translation_dict(self, mock_get, mock_rand):
+    def test_handles_translation_dict(self, mock_get, mock_rand, mock_levels):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
         mock_resp.json.return_value = {
@@ -95,7 +100,7 @@ class FetchFlashcardsTests(unittest.TestCase):
 
         cards = fetch_flashcards('TOKEN')
 
-        self.assertEqual(cards, [Flashcard(front="Savoir", back="to know", frequency="7")])
+        self.assertEqual(cards, [Flashcard(front="Savoir", back="to know", frequency="7", level=1)])
 
     @patch('airtable_data_access.requests.post')
     def test_log_practice(self, mock_post):
@@ -118,6 +123,68 @@ class FetchFlashcardsTests(unittest.TestCase):
             kwargs['json'],
             {'fields': {'Date': '2023-01-01', 'Frequency': '3'}}
         )
+
+
+class LevelsTests(unittest.TestCase):
+    @patch('airtable_data_access.requests.get')
+    def test_fetch_levels(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            'records': [
+                {'fields': {'Frequency': '1', 'level': 3}, 'id': 'rec1'},
+                {'fields': {'Frequency': '2'}, 'id': 'rec2'},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = fetch_levels('TOKEN', ['1', '2', '3'])
+
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], SPACED_REP_URL)
+        formula = "OR(" + ",".join([f"{{Frequency}} = '{i}'" for i in ['1', '2', '3']]) + ")"
+        self.assertEqual(kwargs['params'], {'filterByFormula': formula})
+        self.assertEqual(kwargs['headers'], {'Authorization': 'Bearer TOKEN'})
+        self.assertEqual(result, {'1': 3, '2': 1})
+
+    @patch('airtable_data_access.requests.patch')
+    @patch('airtable_data_access.requests.get')
+    def test_update_level_increment(self, mock_get, mock_patch):
+        get_resp = MagicMock()
+        get_resp.raise_for_status.return_value = None
+        get_resp.json.return_value = {
+            'records': [{'id': 'rec1', 'fields': {'level': 2}}]
+        }
+        mock_get.return_value = get_resp
+
+        patch_resp = MagicMock()
+        patch_resp.raise_for_status.return_value = None
+        mock_patch.return_value = patch_resp
+
+        new_level = update_level('TOKEN', '10', 1)
+
+        mock_get.assert_called_once()
+        mock_patch.assert_called_once()
+        patch_args, patch_kwargs = mock_patch.call_args
+        self.assertEqual(patch_args[0], f"{SPACED_REP_URL}/rec1")
+        self.assertEqual(patch_kwargs['json'], {'fields': {'level': 3}})
+        self.assertEqual(new_level, 3)
+
+    @patch('airtable_data_access.requests.patch')
+    @patch('airtable_data_access.requests.get')
+    def test_update_level_caps(self, mock_get, mock_patch):
+        get_resp = MagicMock()
+        get_resp.raise_for_status.return_value = None
+        get_resp.json.return_value = {
+            'records': [{'id': 'rec1', 'fields': {'level': 5}}]
+        }
+        mock_get.return_value = get_resp
+
+        new_level = update_level('TOKEN', '10', 1)
+
+        mock_patch.assert_not_called()
+        self.assertEqual(new_level, 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- fetch card level information from Airtable and expose new helpers
- implement `update_level` to change spaced repetition progress
- store level on `Flashcard`
- update server endpoint and front-end buttons to change levels
- expand unit tests to cover new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605915d4ac83259eed951990ce413d