### PR TITLE
[french_learning_app] integrate spaced repetition frequencies

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -17,10 +17,41 @@ def get_random_frequencies(count: int = 20, max_frequency: int = 200) -> List[in
     return random.sample(population, count)
 
 
+def fetch_spaced_rep_frequencies(api_key: str, count: int = 5) -> List[int]:
+    """Fetch up to ``count`` frequencies from the spaced_rep table ordered by date."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    params = {
+        "maxRecords": count,
+        "sort[0][field]": "Date",
+        "sort[0][direction]": "asc",
+    }
+    try:
+        resp = requests.get(SPACED_REP_URL, headers=headers, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        freqs: List[int] = []
+        for rec in data.get("records", []):
+            fields = rec.get("fields", {})
+            freq = fields.get("Frequency")
+            if freq is not None:
+                try:
+                    freqs.append(int(freq))
+                except (TypeError, ValueError):
+                    continue
+        return freqs
+    except Exception:
+        print("Error fetching spaced repetition data", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return []
+
+
 def fetch_flashcards(api_key: str) -> List[Flashcard]:
     """Fetch flashcards from Airtable given an API key."""
     headers = {"Authorization": f"Bearer {api_key}"}
-    selected = get_random_frequencies()
+    spaced_freqs = fetch_spaced_rep_frequencies(api_key)
+    random_freqs = get_random_frequencies()
+    unique_randoms = [f for f in random_freqs if f not in spaced_freqs]
+    selected = spaced_freqs + unique_randoms[: 20 - len(spaced_freqs)]
     formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in selected]) + ")"
     params = {
         "maxRecords": 20,


### PR DESCRIPTION
## Summary
- add `fetch_spaced_rep_frequencies` helper
- integrate spaced repetition records into `fetch_flashcards`
- extend unit tests for new spaced repetition logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686072edcae8832581edae930cc82abf