### PR TITLE
[french_learning_app] Add forget endpoint for spaced repetition

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flashcards import flashcards, Flashcard
 import os
 import sys
 from datetime import datetime
-from airtable_data_access import fetch_flashcards, log_practice
+from airtable_data_access import fetch_flashcards, log_practice, log_forget
 
 app = Flask(__name__)
 
@@ -52,6 +52,24 @@ def record_practice():
         return jsonify({"error": "api key missing"}), 500
     date_str = datetime.utcnow().strftime("%Y-%m-%d")
     success = log_practice(api_key, freq, date_str)
+    if not success:
+        return jsonify({"error": "logging failed"}), 500
+    return jsonify({"status": "ok"})
+
+
+@app.route("/api/forget", methods=["POST"])
+def record_forget():
+    """Record forgetting a flashcard."""
+    data = request.get_json(force=True)
+    freq = data.get("frequency")
+    if not freq:
+        return jsonify({"error": "frequency required"}), 400
+    api_key = os.environ.get("AIRTABLE_API_KEY")
+    if not api_key:
+        print("AIRTABLE_API_KEY environment variable not set", file=sys.stderr)
+        return jsonify({"error": "api key missing"}), 500
+    date_str = datetime.utcnow().strftime("%Y-%m-%d")
+    success = log_forget(api_key, freq, date_str)
     if not success:
         return jsonify({"error": "logging failed"}), 500
     return jsonify({"status": "ok"})

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -155,6 +155,14 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ frequency: freq })
                 });
+            } else if (btn.textContent.includes('I Forgot It')) {
+                const card = btn.closest('.flashcard');
+                const freq = card.dataset.frequency;
+                fetch('/api/forget', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ frequency: freq })
+                });
             }
         });
     });

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -10,6 +10,7 @@ from airtable_data_access import (
     fetch_flashcards,
     fetch_spaced_rep_frequencies,
     log_practice,
+    log_forget,
     log_airtable_error,
     build_url,
     AIRTABLE_URL,
@@ -166,7 +167,7 @@ class FetchFlashcardsTests(unittest.TestCase):
         self.assertEqual(kwargs['headers'], headers)
         self.assertEqual(
             kwargs['json'],
-            {'fields': {'Date': '2023-01-01', 'Level': 3}}
+            {'fields': {'Date': '2023-01-01', 'Level': '3'}}
         )
 
     @patch('airtable_data_access.requests.patch')
@@ -193,7 +194,96 @@ class FetchFlashcardsTests(unittest.TestCase):
         self.assertEqual(args[0], f"{SPACED_REP_URL}/rec999")
         self.assertEqual(
             kwargs['json'],
-            {'fields': {'Date': '2023-01-01', 'Level': 5}}
+            {'fields': {'Date': '2023-01-01', 'Level': '5'}}
+        )
+
+    @patch('airtable_data_access.requests.post')
+    @patch('airtable_data_access.requests.get')
+    def test_log_forget_creates_row(self, mock_get, mock_post):
+        get_resp = MagicMock()
+        get_resp.raise_for_status.return_value = None
+        get_resp.json.return_value = {"records": []}
+        mock_get.return_value = get_resp
+
+        post_resp = MagicMock()
+        post_resp.raise_for_status.return_value = None
+        mock_post.return_value = post_resp
+
+        result = log_forget('TOKEN', '3', '2023-01-01')
+
+        self.assertTrue(result)
+        mock_get.assert_called_once()
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], SPACED_REP_URL)
+        headers = {
+            'Authorization': 'Bearer TOKEN',
+            'Content-Type': 'application/json'
+        }
+        self.assertEqual(kwargs['headers'], headers)
+        self.assertEqual(
+            kwargs['json'],
+            {'fields': {'Date': '2023-01-01', 'Frequency': '3', 'Level': 1}}
+        )
+
+    @patch('airtable_data_access.requests.patch')
+    @patch('airtable_data_access.requests.get')
+    def test_log_forget_updates_row(self, mock_get, mock_patch):
+        get_resp = MagicMock()
+        get_resp.raise_for_status.return_value = None
+        get_resp.json.return_value = {
+            "records": [
+                {"id": "rec123", "fields": {"Frequency": "3", "Level": 3}}
+            ]
+        }
+        mock_get.return_value = get_resp
+
+        patch_resp = MagicMock()
+        patch_resp.raise_for_status.return_value = None
+        mock_patch.return_value = patch_resp
+
+        result = log_forget('TOKEN', '3', '2023-01-01')
+
+        self.assertTrue(result)
+        mock_get.assert_called_once()
+        mock_patch.assert_called_once()
+        args, kwargs = mock_patch.call_args
+        self.assertEqual(args[0], f"{SPACED_REP_URL}/rec123")
+        headers = {
+            'Authorization': 'Bearer TOKEN',
+            'Content-Type': 'application/json'
+        }
+        self.assertEqual(kwargs['headers'], headers)
+        self.assertEqual(
+            kwargs['json'],
+            {'fields': {'Date': '2023-01-01', 'Level': '2'}}
+        )
+
+    @patch('airtable_data_access.requests.patch')
+    @patch('airtable_data_access.requests.get')
+    def test_log_forget_mins_level(self, mock_get, mock_patch):
+        get_resp = MagicMock()
+        get_resp.raise_for_status.return_value = None
+        get_resp.json.return_value = {
+            "records": [
+                {"id": "rec999", "fields": {"Frequency": "3", "Level": 1}}
+            ]
+        }
+        mock_get.return_value = get_resp
+
+        patch_resp = MagicMock()
+        patch_resp.raise_for_status.return_value = None
+        mock_patch.return_value = patch_resp
+
+        result = log_forget('TOKEN', '3', '2023-01-01')
+
+        self.assertTrue(result)
+        mock_patch.assert_called_once()
+        args, kwargs = mock_patch.call_args
+        self.assertEqual(args[0], f"{SPACED_REP_URL}/rec999")
+        self.assertEqual(
+            kwargs['json'],
+            {'fields': {'Date': '2023-01-01', 'Level': '1'}}
         )
 
 


### PR DESCRIPTION
## Summary
- allow decrementing spaced repetition level
- expose `/api/forget` endpoint and hook up the button
- test log_forget behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607f9d0b588325987de852be3c7687