### PR TITLE
[french_learning_app] Implement spaced repetition levels

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -33,43 +33,70 @@ def get_random_frequencies(count: int = 20, max_frequency: int = 200) -> List[in
 
 
 def fetch_spaced_rep_frequencies(api_key: str, count: int = 5) -> List[int]:
-    """Fetch up to ``count`` frequencies from the spaced_rep table ordered by date."""
+    """Return a list of flashcard frequencies based on spaced repetition logic.
+
+    ``count`` frequencies are retrieved for each knowledge level from 1-5.
+    Older cards are preferred according to the following schedule:
+
+    - Level 1: at least 1 day old
+    - Level 2: at least 1 week old
+    - Level 3: at least 2 weeks old
+    - Level 4: at least 1 month old
+    - Level 5: no age requirement
+    """
+
     headers = {"Authorization": f"Bearer {api_key}"}
-    params = {
-        "maxRecords": count,
-        "sort[0][field]": "Date",
-        "sort[0][direction]": "asc",
-    }
-    url = build_url(SPACED_REP_URL, params)
-    try:
-        resp = requests.get(SPACED_REP_URL, headers=headers, params=params)
-        resp.raise_for_status()
-        data = resp.json()
-        freqs: List[int] = []
-        for rec in data.get("records", []):
-            fields = rec.get("fields", {})
-            freq = fields.get("Frequency")
-            if freq is not None:
-                try:
-                    freqs.append(int(freq))
-                except (TypeError, ValueError):
-                    continue
-        return freqs
-    except Exception:
-        log_airtable_error("Error fetching spaced repetition data", url)
-        return []
+    level_age = {1: 1, 2: 7, 3: 14, 4: 30, 5: None}
+    freqs: List[int] = []
+
+    for lvl in range(1, 6):
+        age = level_age[lvl]
+        if age is not None:
+            formula = (
+                f"AND({{Level}} = '{lvl}', "
+                f"IS_BEFORE({{Date}}, DATEADD(TODAY(), -{age}, 'day')))"
+            )
+        else:
+            formula = f"{{Level}} = '{lvl}'"
+
+        params = {
+            "maxRecords": count,
+            "filterByFormula": formula,
+            "sort[0][field]": "Date",
+            "sort[0][direction]": "asc",
+        }
+
+        url = build_url(SPACED_REP_URL, params)
+        try:
+            resp = requests.get(SPACED_REP_URL, headers=headers, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+
+            for rec in data.get("records", []):
+                fields = rec.get("fields", {})
+                freq = fields.get("Frequency")
+                if freq is not None:
+                    try:
+                        freqs.append(int(freq))
+                    except (TypeError, ValueError):
+                        continue
+        except Exception:
+            log_airtable_error("Error fetching spaced repetition data", url)
+            continue
+
+    return freqs
 
 
 def fetch_flashcards(api_key: str) -> List[Flashcard]:
-    """Fetch flashcards from Airtable given an API key."""
+    """Fetch a set of flashcards using spaced repetition rules."""
     headers = {"Authorization": f"Bearer {api_key}"}
     spaced_freqs = fetch_spaced_rep_frequencies(api_key)
-    random_freqs = get_random_frequencies()
+    random_freqs = get_random_frequencies(count=25)
     unique_randoms = [f for f in random_freqs if f not in spaced_freqs]
-    selected = spaced_freqs + unique_randoms[: 20 - len(spaced_freqs)]
+    selected = spaced_freqs + unique_randoms[: 25 - len(spaced_freqs)]
     formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in selected]) + ")"
     params = {
-        "maxRecords": 20,
+        "maxRecords": 25,
         "filterByFormula": formula,
         "sort[0][field]": "Frequency",
         "sort[0][direction]": "asc",


### PR DESCRIPTION
## Summary
- implement level-aware spaced repetition logic in `airtable_data_access`
- update flashcard retrieval to fetch 25 cards
- adjust and extend unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656b70a0e883258b36d6d5e82c7d7b