### PR TITLE
[french_learning_app] Add level badges and banners

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -94,7 +94,7 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
     random_freqs = get_random_frequencies(count=25)
     unique_randoms = [f for f in random_freqs if f not in spaced_freqs]
     selected = spaced_freqs + unique_randoms[: 25 - len(spaced_freqs)]
-    formula = "OR(" + ",".join([f"{{Frequency}} = \"{i}\"" for i in selected]) + ")"
+    formula = "OR(" + ",".join([f'{{Frequency}} = "{i}"' for i in selected]) + ")"
     params = {
         "maxRecords": 25,
         "filterByFormula": formula,
@@ -112,9 +112,12 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
             front = fields.get("french_word", "")
             back = fields.get("english_translation", {}).get("value", "")
             freq = str(fields.get("Frequency", ""))
+            level = (
+                str(fields.get("Level")) if fields.get("Level") is not None else None
+            )
             if front or back:
                 flashcards.append(
-                    Flashcard(front=front, back=back, frequency=freq)
+                    Flashcard(front=front, back=back, frequency=freq, level=level)
                 )
         return flashcards
     except Exception:
@@ -221,7 +224,7 @@ def log_forget(api_key: str, frequency: str, date_str: str) -> bool:
             resp = requests.patch(update_url, headers=headers, json=payload)
         else:
             payload = {
-                "fields": {"Date": date_str, "Frequency": frequency, "Level": 1}
+                "fields": {"Date": date_str, "Frequency": frequency, "Level": "1"}
             }
             current_url = SPACED_REP_URL
             resp = requests.post(SPACED_REP_URL, headers=headers, json=payload)

--- a/flashcards.py
+++ b/flashcards.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 @dataclass
 class Flashcard:
     front: str  # French word
-    back: str   # English translation
+    back: str  # English translation
     frequency: str | None = None
+    level: str | None = None
 
 
 # Initial set of flashcards

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -45,6 +45,31 @@
             border-radius: 8px;
             backface-visibility: hidden;
             font-weight: bold;
+            overflow: hidden;
+        }
+        .level-banner {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 8px;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+        }
+        .level-badge {
+            position: absolute;
+            top: -12px;
+            right: -12px;
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            font-weight: bold;
+            border: 1px solid #000;
+            background: #fff;
         }
         .front {
             background: lightblue;
@@ -100,11 +125,25 @@
     </style>
 </head>
 <body>
+    {% set level_colors = {
+        '1': '#FDEDEC',
+        '2': '#FDEBD0',
+        '3': '#FCF3CF',
+        '4': '#E9F7EF',
+        '5': '#E8F8F5'
+    } %}
     <div id="card-container">
         {% for card in flashcards %}
+        {% set lvl = card.level or '1' %}
+        {% set color = level_colors.get(lvl, '#FDEDEC') %}
         <div class="flashcard{% if loop.index0 == 0 %} active{% endif %}" data-frequency="{{ card.frequency }}">
-            <div class="side front">{{ card.front }}</div>
+            <div class="level-badge" style="background: {{ color }};">{{ lvl }}</div>
+            <div class="side front">
+                <div class="level-banner" style="background: {{ color }};"></div>
+                {{ card.front }}
+            </div>
             <div class="side back">
+                <div class="level-banner" style="background: {{ color }};"></div>
                 <div class="back-text">{{ card.back }}</div>
                 <div class="back-buttons">
                     <button type="button" class="back-action">I Got It</button>


### PR DESCRIPTION
## Summary
- show level color strip and circular badge on flashcards
- parse optional `Level` from Airtable records
- handle level as a field on Flashcard dataclass
- expect string `Level` values in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865721fe81c8325a8f62aec453bb4c1