### PR TITLE
[french_learning_app] Update flashcard UI styling

### DIFF
--- a/templates/flashcards.html
+++ b/templates/flashcards.html
@@ -4,9 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Flashcards</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
     <style>
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
+            color: #333;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -40,21 +42,25 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            border: 1px solid #000;
+            border: 1px solid #333;
             border-radius: 8px;
             backface-visibility: hidden;
             background: #fff;
             font-weight: bold;
+            color: #333;
         }
         .back {
             transform: rotateY(180deg);
-            color: blue;
+            color: #333;
         }
         nav {
             margin-top: 20px;
         }
         button {
             padding: 10px 20px;
+            color: #333;
+            border: 1px solid #333;
+            background: #fff;
         }
         @media (max-width: 500px) {
             #card-container {

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -4,9 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Flashcards</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
     <style>
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Poppins', sans-serif;
+            color: #333;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -41,25 +43,27 @@
             flex-direction: column;
             justify-content: center;
             align-items: center;
-            border: 1px solid #000;
+            border: 1px solid #333;
             border-radius: 8px;
             backface-visibility: hidden;
             font-weight: bold;
             overflow: hidden;
+            color: #333;
+            background: #fff;
         }
         .level-banner {
             position: absolute;
             top: 0;
             left: 0;
             right: 0;
-            height: 8px;
+            height: 16px;
             border-top-left-radius: 8px;
             border-top-right-radius: 8px;
         }
         .level-badge {
             position: absolute;
-            top: -12px;
-            right: -12px;
+            top: 20px;
+            right: 8px;
             width: 30px;
             height: 30px;
             border-radius: 50%;
@@ -68,18 +72,19 @@
             justify-content: center;
             font-size: 14px;
             font-weight: bold;
-            border: 1px solid #000;
+            border: 1px solid #333;
             background: #fff;
+            color: #333;
         }
         .front {
-            background: lightblue;
-            color: #000;
+            background: #fff;
+            color: #333;
             font-size: 24pt;
         }
         .back {
             transform: rotateY(180deg);
-            background: lightgreen;
-            color: #000;
+            background: #fff;
+            color: #333;
             font-size: 24pt;
         }
         .back-text {
@@ -99,10 +104,11 @@
         .back-buttons button {
             font-size: 12pt;
             padding: 5px 10px;
+            color: #333;
         }
         .back-buttons button:disabled {
             background: #ccc;
-            color: #666;
+            color: #333;
             cursor: default;
         }
         nav {
@@ -110,6 +116,9 @@
         }
         button {
             padding: 10px 20px;
+            color: #333;
+            border: 1px solid #333;
+            background: #fff;
         }
         @media (max-width: 500px) {
             #card-container {


### PR DESCRIPTION
## Summary
- use Poppins font with dark grey text
- enlarge level banner and move level badge below it
- remove flashcard background colors and keep cards white

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657610163c8325a767dc1e99765eaa