### PR TITLE
[french_learning_app] decouple translate_words

### DIFF
--- a/scripts/translate_words.py
+++ b/scripts/translate_words.py
@@ -1,10 +1,16 @@
 import argparse
 import sys
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import requests
 
-from airtable_data_access import AIRTABLE_URL, build_url
+AIRTABLE_URL = "https://api.airtable.com/v0/applW7zbiH23gDDCK/french_words"
+
+
+def build_url(base_url: str, params: Optional[dict] = None) -> str:
+    """Return ``base_url`` with ``params`` encoded as query string."""
+    req = requests.Request("GET", base_url, params=params)
+    return req.prepare().url
 
 
 def parse_frequency_range(range_str: str) -> Tuple[int, int]:

--- a/tests/test_translate_words.py
+++ b/tests/test_translate_words.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from scripts.translate_words import parse_frequency_range, fetch_words
-from airtable_data_access import AIRTABLE_URL
+from scripts.translate_words import parse_frequency_range, fetch_words, AIRTABLE_URL
 
 
 class ParseFrequencyRangeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- inline Airtable configuration and helper in `translate_words`
- update tests to import constants from the script

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657b2205a88325aa0a9ce122c89fff