### PR TITLE
[french_learning_app] Add level badges and rounded buttons

### DIFF
--- a/flashcards.py
+++ b/flashcards.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 @dataclass
 class Flashcard:
+    """Simple container for a flashcard."""
+
     front: str  # French word
     back: str  # English translation
     frequency: str | None = None
@@ -11,19 +13,20 @@ class Flashcard:
 
 # Initial set of flashcards
 flashcards = [
-    Flashcard(front="Le Chat", back="Cat"),
-    Flashcard(front="Le Chien", back="Dog"),
-    Flashcard(front="La Maison", back="House"),
-    Flashcard(front="Le Homme", back="Man"),
-    Flashcard(front="L'Amour", back="Love"),
-    Flashcard(front="Savoir", back="To Know"),
-    Flashcard(front="Parler", back="To Talk"),
-    Flashcard(front="L'Ordinateur", back="Computer"),
-    Flashcard(front="La Norriture", back="Food"),
-    Flashcard(front="Le Verre", back="Glass"),
-    Flashcard(front="L'ecole", back="School"),
-    Flashcard(front="Le nuit", back="Night"),
-    Flashcard(front="Bonjour", back="Hello (Day)"),
-    Flashcard(front="Bonsoir", back="Hello (Night)"),
-    Flashcard(front="Voir", back="To See"),
+    # Levels are repeated so the UI can demonstrate color coding for each one
+    Flashcard(front="Le Chat", back="Cat", level="1"),
+    Flashcard(front="Le Chien", back="Dog", level="2"),
+    Flashcard(front="La Maison", back="House", level="3"),
+    Flashcard(front="Le Homme", back="Man", level="4"),
+    Flashcard(front="L'Amour", back="Love", level="5"),
+    Flashcard(front="Savoir", back="To Know", level="1"),
+    Flashcard(front="Parler", back="To Talk", level="2"),
+    Flashcard(front="L'Ordinateur", back="Computer", level="3"),
+    Flashcard(front="La Norriture", back="Food", level="4"),
+    Flashcard(front="Le Verre", back="Glass", level="5"),
+    Flashcard(front="L'ecole", back="School", level="1"),
+    Flashcard(front="Le nuit", back="Night", level="2"),
+    Flashcard(front="Bonjour", back="Hello (Day)", level="3"),
+    Flashcard(front="Bonsoir", back="Hello (Night)", level="4"),
+    Flashcard(front="Voir", back="To See", level="5"),
 ]

--- a/templates/flashcards.html
+++ b/templates/flashcards.html
@@ -35,6 +35,32 @@
         .flashcard.flipped {
             transform: rotateY(180deg);
         }
+        .level-banner {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 16px;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+        }
+
+        .level-badge {
+            position: absolute;
+            top: 20px;
+            right: 8px;
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            font-weight: bold;
+            border: 1px solid #333;
+            color: #333;
+        }
+
         .side {
             position: absolute;
             width: 100%;
@@ -61,6 +87,7 @@
             color: #333;
             border: 1px solid #333;
             background: #fff;
+            border-radius: 8px;
         }
         @media (max-width: 500px) {
             #card-container {
@@ -76,11 +103,27 @@
     </style>
 </head>
 <body>
+    {% set level_colors = {
+        '1': '#FDEDEC',
+        '2': '#FDEBD0',
+        '3': '#FCF3CF',
+        '4': '#E9F7EF',
+        '5': '#E8F8F5'
+    } %}
     <div id="card-container">
         {% for card in flashcards %}
+        {% set lvl = card.level or '1' %}
+        {% set color = level_colors.get(lvl, '#FDEDEC') %}
         <div class="flashcard{% if loop.index0 == 0 %} active{% endif %}">
-            <div class="side front">{{ card.front }}</div>
-            <div class="side back">{{ card.back }}</div>
+            <div class="level-badge" style="background: {{ color }};">{{ lvl }}</div>
+            <div class="side front">
+                <div class="level-banner" style="background: {{ color }};"></div>
+                {{ card.front }}
+            </div>
+            <div class="side back">
+                <div class="level-banner" style="background: {{ color }};"></div>
+                {{ card.back }}
+            </div>
         </div>
         {% endfor %}
     </div>

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -73,7 +73,6 @@
             font-size: 14px;
             font-weight: bold;
             border: 1px solid #333;
-            background: #fff;
             color: #333;
         }
         .front {
@@ -105,6 +104,7 @@
             font-size: 12pt;
             padding: 5px 10px;
             color: #333;
+            border-radius: 8px;
         }
         .back-buttons button:disabled {
             background: #ccc;
@@ -119,6 +119,7 @@
             color: #333;
             border: 1px solid #333;
             background: #fff;
+            border-radius: 8px;
         }
         @media (max-width: 500px) {
             #card-container {


### PR DESCRIPTION
## Summary
- assign levels to example flashcards
- display level badges on static flashcards page
- round all buttons and remove redundant badge background

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657b71875c832595e3f175d84c236f