### PR TITLE
[French Learning App] Expand card banner and show level badge

### DIFF
--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -56,21 +56,21 @@
             top: 0;
             left: 0;
             right: 0;
-            height: 16px;
+            height: 32px;
             border-top-left-radius: 8px;
             border-top-right-radius: 8px;
         }
         .level-badge {
             position: absolute;
-            top: 20px;
-            right: 8px;
-            width: 30px;
-            height: 30px;
+            top: 4px;
+            right: 4px;
+            width: 24px;
+            height: 24px;
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 14px;
+            font-size: 12px;
             font-weight: bold;
             border: 1px solid #333;
             color: #333;


### PR DESCRIPTION
## Summary
- widen the level banner on each flashcard
- show a small badge with the card level

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flashcards')*

------
https://chatgpt.com/codex/tasks/task_e_6865872b73a88325a03cc6807c4d5521