### PR TITLE
[French Learning App] Show level badge

### DIFF
--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -74,6 +74,7 @@
             font-weight: bold;
             border: 1px solid #333;
             color: #333;
+            z-index: 2;
         }
         .front {
             background: #fff;

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -17,7 +17,6 @@ from airtable_data_access import (
     SPACED_REP_URL,
     Flashcard
 )
-from flashcards import Flashcard
 
 
 class FetchFlashcardsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ensure level badge displays above flashcard content
- fix stray import in the Airtable data access tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658aa1e054832596000f843d4f221a