### PR TITLE
[french_learning_app] fix level parsing and add logging

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -98,6 +98,7 @@ def fetch_spaced_rep_frequencies(api_key: str, count: int = 5) -> List[Tuple[int
             continue
 
     # Sort so that unit tests have deterministic output
+    print(f"Fetched spaced repetition levels: {sorted(results)}")
     return sorted(results)
 
 
@@ -128,9 +129,11 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
             fields = rec.get("fields", {})
             front = fields.get("french_word", "")
             back = fields.get("english_translation", {}).get("value", "")
-            freq_str = str(fields.get("Frequency", ""))
+            freq_raw = fields.get("Frequency", "")
+            # ``Frequency`` may come back as an int or float from Airtable.
+            freq_str = str(freq_raw)
             try:
-                freq_int = int(freq_str)
+                freq_int = int(float(freq_raw))
             except (TypeError, ValueError):
                 freq_int = None
             level = str(spaced_map.get(freq_int, 1)) if freq_int is not None else "1"
@@ -138,6 +141,7 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
                 flashcards.append(
                     Flashcard(front=front, back=back, frequency=freq_str, level=level)
                 )
+        print("Returning flashcards with levels:", [f"{c.front}:{c.level}" for c in flashcards])
         return flashcards
     except Exception:
         log_airtable_error("Error fetching flashcards from Airtable", url)

--- a/app.py
+++ b/app.py
@@ -16,6 +16,10 @@ def flashcards_airtable_page():
         airtable_cards = []
     else:
         airtable_cards = fetch_flashcards(api_key)
+        print(
+            "Loaded flashcards:",
+            [f"{c.front}:{c.level}" for c in airtable_cards],
+        )
 
     return render_template(
         "flashcards_airtable.html",

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -153,6 +153,62 @@ class FetchFlashcardsTests(unittest.TestCase):
             [Flashcard(front="Bonjour", back="Hello", frequency="2", level="3")],
         )
 
+    @patch(
+        "airtable_data_access.get_random_frequencies", return_value=list(range(1, 26))
+    )
+    @patch("airtable_data_access.fetch_spaced_rep_frequencies", return_value=[])
+    @patch("airtable_data_access.requests.get")
+    def test_handles_float_frequency(self, mock_get, mock_spaced, mock_rand):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "records": [
+                {
+                    "fields": {
+                        "french_word": "Bonjour",
+                        "english_translation": {"value": "Hello"},
+                        "Frequency": 2.0,
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        cards = fetch_flashcards("TOKEN")
+
+        self.assertEqual(
+            cards,
+            [Flashcard(front="Bonjour", back="Hello", frequency="2.0", level="1")],
+        )
+
+    @patch(
+        "airtable_data_access.get_random_frequencies", return_value=list(range(1, 26))
+    )
+    @patch("airtable_data_access.fetch_spaced_rep_frequencies", return_value=[(2, 4)])
+    @patch("airtable_data_access.requests.get")
+    def test_assigns_levels_with_float_frequency(self, mock_get, mock_spaced, mock_rand):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "records": [
+                {
+                    "fields": {
+                        "french_word": "Bonjour",
+                        "english_translation": {"value": "Hello"},
+                        "Frequency": 2.0,
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        cards = fetch_flashcards("TOKEN")
+
+        self.assertEqual(
+            cards,
+            [Flashcard(front="Bonjour", back="Hello", frequency="2.0", level="4")],
+        )
+
     @patch("airtable_data_access.requests.post")
     @patch("airtable_data_access.requests.get")
     def test_log_practice_creates_row(self, mock_get, mock_post):


### PR DESCRIPTION
## Summary
- ensure frequency values like `2.0` are parsed correctly
- log spaced repetition levels and flashcards passed to the template
- log flashcards at the route level
- test handling of float frequency values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f4337de08325b2d800966cf0136e