### PR TITLE
[french_learning_app] replace prints with logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,23 +2,25 @@ from flask import Flask, jsonify, render_template, request
 from dataclasses import asdict
 import os
 import sys
+import logging
 from datetime import datetime
 from airtable_data_access import fetch_flashcards, log_practice, log_forget
 
 app = Flask(__name__)
+
+logger = logging.getLogger(__name__)
 
 @app.route("/flashcards_airtable")
 def flashcards_airtable_page():
     """Render flashcards from Airtable."""
     api_key = os.environ.get("AIRTABLE_API_KEY")
     if not api_key:
-        print("AIRTABLE_API_KEY environment variable not set", file=sys.stderr)
+        logger.error("AIRTABLE_API_KEY environment variable not set")
         airtable_cards = []
     else:
         airtable_cards = fetch_flashcards(api_key)
-        print(
-            "Loaded flashcards:",
-            [f"{c.front}:{c.level}" for c in airtable_cards],
+        logger.info(
+            "Loaded flashcards: %s", [f"{c.front}:{c.level}" for c in airtable_cards]
         )
 
     return render_template(
@@ -36,7 +38,7 @@ def record_practice():
         return jsonify({"error": "frequency required"}), 400
     api_key = os.environ.get("AIRTABLE_API_KEY")
     if not api_key:
-        print("AIRTABLE_API_KEY environment variable not set", file=sys.stderr)
+        logger.error("AIRTABLE_API_KEY environment variable not set")
         return jsonify({"error": "api key missing"}), 500
     date_str = datetime.utcnow().strftime("%Y-%m-%d")
     success = log_practice(api_key, freq, date_str)
@@ -54,7 +56,7 @@ def record_forget():
         return jsonify({"error": "frequency required"}), 400
     api_key = os.environ.get("AIRTABLE_API_KEY")
     if not api_key:
-        print("AIRTABLE_API_KEY environment variable not set", file=sys.stderr)
+        logger.error("AIRTABLE_API_KEY environment variable not set")
         return jsonify({"error": "api key missing"}), 500
     date_str = datetime.utcnow().strftime("%Y-%m-%d")
     success = log_forget(api_key, freq, date_str)
@@ -63,5 +65,6 @@ def record_forget():
     return jsonify({"status": "ok"})
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     port = int(os.environ.get("PORT", 5000))
     app.run(host="0.0.0.0", port=port)

--- a/scripts/translate_words.py
+++ b/scripts/translate_words.py
@@ -1,10 +1,13 @@
 import argparse
 import sys
+import logging
 from typing import List, Optional, Tuple
 
 import requests
 
 AIRTABLE_URL = "https://api.airtable.com/v0/applW7zbiH23gDDCK/french_words"
+
+logger = logging.getLogger(__name__)
 
 
 def build_url(base_url: str, params: Optional[dict] = None) -> str:
@@ -49,7 +52,7 @@ def fetch_words(api_key: str, start: int, end: int) -> List[str]:
         resp = requests.get(AIRTABLE_URL, headers=headers, params=params)
         resp.raise_for_status()
     except Exception:
-        print(f"Error fetching records. URL: {url}", file=sys.stderr)
+        logger.error("Error fetching records. URL: %s", url, exc_info=True)
         raise
 
     data = resp.json()
@@ -80,14 +83,15 @@ def main(argv: List[str] | None = None) -> int:
     parser.add_argument("--api_key", help="Airtable API key")
     args = parser.parse_args(argv)
 
-    print(f"args.freq_range: {args.freq_range}")
+    logger.info("args.freq_range: %s", args.freq_range)
 
     start, end = parse_frequency_range(args.freq_range)
     words = fetch_words(args.api_key, start, end)
     for w in words:
-        print(w)
+        logger.info("%s", w)
     return 0
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     raise SystemExit(main())

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import unittest
-import io
 from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -405,15 +404,12 @@ class LogAirtableErrorTests(unittest.TestCase):
     def test_log_airtable_error_outputs_url_and_json(self):
         payload = {"a": 1, "b": 2}
         url = "https://example.com/path"
-        with patch("traceback.print_exc") as mock_trace, patch(
-            "sys.stderr", new_callable=io.StringIO
-        ) as fake_err:
+        with self.assertLogs("airtable_data_access", level="ERROR") as cm:
             log_airtable_error("Test error", url, payload)
-            output = fake_err.getvalue()
+        output = "\n".join(cm.output)
         self.assertIn("Test error. URL: https://example.com/path", output)
         self.assertIn('"a": 1', output)
         self.assertIn('"b": 2', output)
-        mock_trace.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch to Python's logging instead of prints
- update log_airtable_error helper
- log missing API key errors in Flask routes
- log translator script activity
- adjust tests for logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670e1723848325bb07663c5caad379