### PR TITLE
[french_learning_app] Add GPT-4 translation capability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+openai

--- a/tests/test_translate_words.py
+++ b/tests/test_translate_words.py
@@ -1,7 +1,12 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from scripts.translate_words import parse_frequency_range, fetch_words, AIRTABLE_URL
+from scripts.translate_words import (
+    parse_frequency_range,
+    fetch_words,
+    translate_word,
+    AIRTABLE_URL,
+)
 
 
 class ParseFrequencyRangeTests(unittest.TestCase):
@@ -40,6 +45,18 @@ class FetchWordsTests(unittest.TestCase):
         params = kwargs["params"]
         self.assertIn("filterByFormula", params)
         self.assertEqual(result, ["bonjour", "chat"])
+
+
+class TranslateWordTests(unittest.TestCase):
+    @patch("scripts.translate_words.openai.ChatCompletion.create")
+    def test_translate_word(self, mock_create):
+        mock_create.return_value = {
+            "choices": [{"message": {"content": "bonjour"}}]
+        }
+        result = translate_word("OPENAI", "hello")
+
+        mock_create.assert_called_once()
+        self.assertEqual(result, "bonjour")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- translate words using OpenAI GPT-4
- expose `--translate` and `--open_ai_api_key` flags in translate_words script
- unit test translation logic
- add openai to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876866ca5b0832583aefc8c6b83aa53