### PR TITLE
[french_learning_app] fix mirrored level badge on flip

### DIFF
--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -75,6 +75,10 @@
             border: 1px solid #333;
             color: #333;
             z-index: 2;
+            backface-visibility: hidden;
+        }
+        .flashcard.flipped .level-badge {
+            transform: rotateY(180deg);
         }
         .front {
             background: #fff;


### PR DESCRIPTION
## Summary
- ensure level badge doesn't appear mirrored when flipping cards
- adjust CSS so badge rotates back

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b03a033883258323c33a352cb23e