### PR TITLE
[french_learning_app] Enhance translate script with structured output

### DIFF
--- a/prompts/TRANSLATE_PROMPT.txt
+++ b/prompts/TRANSLATE_PROMPT.txt
@@ -1,1 +1,10 @@
-Translate the French word '{{ word }}' into English. Respond only with the English translation. If the word cannot be translated directly, respond with 'N/A'.
+Translate the French word '{{ word }}' into English and return a JSON object with the following keys:
+
+- ``english_word`` - the English translation
+- ``french_word`` - the original French word prefixed by the correct article (le, la or l')
+- ``sentence_one`` - a French example sentence of less than 7 words using the word
+- ``sentence_two`` - another short French sentence of less than 7 words using the word
+- ``part_of_speech`` - the part of speech
+- ``gender`` - ``masculine`` or ``feminine`` if applicable, otherwise ``N/A``
+
+Respond only with valid JSON.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
 requests
-openai
+openai>=1.0.0
 pytest
 Jinja2


### PR DESCRIPTION
## Summary
- extend TRANSLATE_PROMPT for JSON structured answers
- parse translation JSON using OpenAI structured outputs
- pretty print translation data before generating images
- adjust requirements for OpenAI 1.x
- update tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc2b915608325b2c95fc7e2de0152