### PR TITLE
[french_learning_app] show extra info on flashcards

### DIFF
--- a/airtable_data_access.py
+++ b/airtable_data_access.py
@@ -14,12 +14,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Flashcard:
-    """Container for a single flashcard."""
+    """Container for a single flashcard loaded from Airtable."""
 
     front: str
     back: str
     frequency: str | None = None
     level: str | None = None
+    gender: str | None = None
+    part_of_speech: str | None = None
+    example_1: str | None = None
+    example_2: str | None = None
 
 def build_url(base_url: str, params: Optional[dict] = None) -> str:
     """Return ``base_url`` with ``params`` encoded as query string."""
@@ -138,6 +142,10 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
             front = fields.get("french_word", "")
             back = fields.get("english_translation", {}).get("value", "")
             freq_raw = fields.get("Frequency", "")
+            gender = fields.get("gender")
+            part_of_speech = fields.get("part_of_speech")
+            example_1 = fields.get("example_1")
+            example_2 = fields.get("example_2")
             # ``Frequency`` may come back as an int or float from Airtable.
             freq_str = str(freq_raw)
             try:
@@ -147,7 +155,16 @@ def fetch_flashcards(api_key: str) -> List[Flashcard]:
             level = str(spaced_map.get(freq_int, 1)) if freq_int is not None else "1"
             if front or back:
                 flashcards.append(
-                    Flashcard(front=front, back=back, frequency=freq_str, level=level)
+                    Flashcard(
+                        front=front,
+                        back=back,
+                        frequency=freq_str,
+                        level=level,
+                        gender=gender,
+                        part_of_speech=part_of_speech,
+                        example_1=example_1,
+                        example_2=example_2,
+                    )
                 )
         logger.info(
             "Returning flashcards with levels: %s",

--- a/templates/flashcards_airtable.html
+++ b/templates/flashcards_airtable.html
@@ -155,7 +155,12 @@
             <div class="level-badge" style="background: {{ color }};">{{ lvl }}</div>
             <div class="side front">
                 <div class="level-banner" style="background: {{ color }};"></div>
-                {{ card.front }}
+                <div>{{ card.front }}</div>
+                <div style="font-size: 12pt; text-align: center;">
+                    <div>{{ card.gender }} {{ card.part_of_speech }}</div>
+                    <div>{{ card.example_1 }}</div>
+                    <div>{{ card.example_2 }}</div>
+                </div>
             </div>
             <div class="side back">
                 <div class="level-banner" style="background: {{ color }};"></div>

--- a/tests/test_airtable_data_access.py
+++ b/tests/test_airtable_data_access.py
@@ -88,8 +88,67 @@ class FetchFlashcardsTests(unittest.TestCase):
         self.assertEqual(
             cards,
             [
-                Flashcard(front="Bonjour", back="Hello", frequency="2", level="1"),
-                Flashcard(front="", back="Empty", frequency="5", level="1"),
+                Flashcard(
+                    front="Bonjour",
+                    back="Hello",
+                    frequency="2",
+                    level="1",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                ),
+                Flashcard(
+                    front="",
+                    back="Empty",
+                    frequency="5",
+                    level="1",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                ),
+            ],
+        )
+
+    @patch("airtable_data_access.get_random_frequencies", return_value=list(range(1, 26)))
+    @patch("airtable_data_access.fetch_spaced_rep_frequencies", return_value=[])
+    @patch("airtable_data_access.requests.get")
+    def test_parses_additional_fields(self, mock_get, mock_spaced, mock_rand):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "records": [
+                {
+                    "fields": {
+                        "french_word": "Bonjour",
+                        "english_translation": {"value": "Hello"},
+                        "Frequency": "2",
+                        "gender": "masc",
+                        "part_of_speech": "noun",
+                        "example_1": "bonjour le monde",
+                        "example_2": "bonjour les amis",
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        cards = fetch_flashcards("TOKEN")
+
+        self.assertEqual(
+            cards,
+            [
+                Flashcard(
+                    front="Bonjour",
+                    back="Hello",
+                    frequency="2",
+                    level="1",
+                    gender="masc",
+                    part_of_speech="noun",
+                    example_1="bonjour le monde",
+                    example_2="bonjour les amis",
+                )
             ],
         )
 
@@ -121,7 +180,19 @@ class FetchFlashcardsTests(unittest.TestCase):
         cards = fetch_flashcards("TOKEN")
 
         self.assertEqual(
-            cards, [Flashcard(front="Savoir", back="to know", frequency="7", level="1")]
+            cards,
+            [
+                Flashcard(
+                    front="Savoir",
+                    back="to know",
+                    frequency="7",
+                    level="1",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                )
+            ],
         )
 
     @patch(
@@ -149,7 +220,18 @@ class FetchFlashcardsTests(unittest.TestCase):
 
         self.assertEqual(
             cards,
-            [Flashcard(front="Bonjour", back="Hello", frequency="2", level="3")],
+            [
+                Flashcard(
+                    front="Bonjour",
+                    back="Hello",
+                    frequency="2",
+                    level="3",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                )
+            ],
         )
 
     @patch(
@@ -177,7 +259,18 @@ class FetchFlashcardsTests(unittest.TestCase):
 
         self.assertEqual(
             cards,
-            [Flashcard(front="Bonjour", back="Hello", frequency="2.0", level="1")],
+            [
+                Flashcard(
+                    front="Bonjour",
+                    back="Hello",
+                    frequency="2.0",
+                    level="1",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                )
+            ],
         )
 
     @patch(
@@ -205,7 +298,18 @@ class FetchFlashcardsTests(unittest.TestCase):
 
         self.assertEqual(
             cards,
-            [Flashcard(front="Bonjour", back="Hello", frequency="2.0", level="4")],
+            [
+                Flashcard(
+                    front="Bonjour",
+                    back="Hello",
+                    frequency="2.0",
+                    level="4",
+                    gender=None,
+                    part_of_speech=None,
+                    example_1=None,
+                    example_2=None,
+                )
+            ],
         )
 
     @patch("airtable_data_access.requests.post")

--- a/tests/test_translate_words.py
+++ b/tests/test_translate_words.py
@@ -112,7 +112,8 @@ class GenerateImageTests(unittest.TestCase):
 class UploadFunctionsTests(unittest.TestCase):
     @patch("scripts.translate_words.requests.post")
     @patch("scripts.translate_words.Image.open")
-    def test_upload_image_to_airtable(self, mock_open_image, mock_post):
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    def test_upload_image_to_airtable(self, mock_file, mock_open_image, mock_post):
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = {"id": "att123"}


### PR DESCRIPTION
## Summary
- include gender, part of speech and examples in the Flashcard dataclass
- parse additional fields from Airtable
- render gender, part-of-speech and example sentences on flashcard front side
- adjust airtable access tests for new dataclass fields and add a new test
- fix image upload test by patching builtins.open

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be22adc1483258dcf496d3f04685e